### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bwedderburn/bm83-pico2w-nextion/security/code-scanning/1](https://github.com/bwedderburn/bm83-pico2w-nextion/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the workflow that sets the minimum privileges required for its tasks. For Python package workflows that install dependencies, lint, and run tests – but do not push back to the repository, open issues, or modify pull requests – the minimal permission required is `contents: read`. The recommended place to add this block is at the top level of the YAML file, just below the workflow `name:` but above the `on:` key, so that permissions apply to all jobs unless further restricted. You do not need to modify any steps or add any imports; this is a YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
