### PR TITLE
Update AVRCP play-state cache from PlaybackStatusChanged notifications

### DIFF
--- a/firmware/circuitpython/blehid/ble.py
+++ b/firmware/circuitpython/blehid/ble.py
@@ -437,12 +437,14 @@ class BleHid:
 
             ok = False
             has_radio_erase = hasattr(self._ble, "erase_bonding")
+            radio_erase_failed = False
             try:
                 if has_radio_erase:
                     self._ble.erase_bonding()
                     ok = True
             except Exception as e:
                 dprint("[BLE] erase_bonding err:", e)
+                radio_erase_failed = True
                 ok = False
 
             # Fallback to _bleio.adapter only when BLERadio does not expose erase_bonding.
@@ -458,7 +460,13 @@ class BleHid:
                     dprint("[BLE] _bleio.adapter.erase_bonding err:", e)
                     ok = False
 
-            print("[BLE] erase_bonding:", "OK" if ok else "Unavailable on this build")
+            if ok:
+                erase_status = "OK"
+            elif has_radio_erase and radio_erase_failed:
+                erase_status = "FAILED"
+            else:
+                erase_status = "Unavailable on this build"
+            print("[BLE] erase_bonding:", erase_status)
 
             # Brief delay after erase_bonding to allow BLE stack to stabilize
             # before updating name and restarting advertising

--- a/firmware/circuitpython/blehid/ble.py
+++ b/firmware/circuitpython/blehid/ble.py
@@ -437,14 +437,12 @@ class BleHid:
 
             ok = False
             has_radio_erase = hasattr(self._ble, "erase_bonding")
-            radio_erase_failed = False
             try:
                 if has_radio_erase:
                     self._ble.erase_bonding()
                     ok = True
             except Exception as e:
                 dprint("[BLE] erase_bonding err:", e)
-                radio_erase_failed = True
                 ok = False
 
             # Fallback to _bleio.adapter only when BLERadio does not expose erase_bonding.
@@ -462,7 +460,7 @@ class BleHid:
 
             if ok:
                 erase_status = "OK"
-            elif has_radio_erase and radio_erase_failed:
+            elif has_radio_erase and not ok:
                 erase_status = "FAILED"
             else:
                 erase_status = "Unavailable on this build"

--- a/firmware/circuitpython/blehid/ble.py
+++ b/firmware/circuitpython/blehid/ble.py
@@ -436,15 +436,19 @@ class BleHid:
             gc.collect()
 
             ok = False
+            has_radio_erase = hasattr(self._ble, "erase_bonding")
             try:
-                if hasattr(self._ble, "erase_bonding"):
+                if has_radio_erase:
                     self._ble.erase_bonding()
                     ok = True
             except Exception as e:
                 dprint("[BLE] erase_bonding err:", e)
                 ok = False
 
-            if not ok:
+            # Fallback to _bleio.adapter only when BLERadio does not expose erase_bonding.
+            # If BLERadio.erase_bonding() exists but fails, do not chain another low-level
+            # erase call in the same cycle; this reduces BLE stack stress on ESP32-S3.
+            if not ok and not has_radio_erase:
                 try:
                     import _bleio
                     if hasattr(_bleio.adapter, "erase_bonding"):

--- a/firmware/circuitpython/main.py
+++ b/firmware/circuitpython/main.py
@@ -5,7 +5,7 @@ import busio
 
 # endregion
 from utils.common import dprint, _fmt_ms, _sanitize_text
-from nextion.display import Nextion, NX_RUNTIME, EQ_OBJ_PAGE0, EQ_OBJ_PAGE1, AUX_OBJ_PAGE1
+from nextion.display import Nextion, NX_RUNTIME, EQ_OBJ_PAGE0, EQ_OBJ_PAGE1, AUX_OBJ_PAGE0, AUX_OBJ_PAGE1
 from blehid.ble import BleHid
 from bm83.bm83 import Bm83
 
@@ -78,8 +78,11 @@ def main():
     last_avrcp_rx_at = 0.0
     last_pos_ms = None
     last_total_ms = None
+    last_play_status = None
     last_voldn_at = 0.0
     mute_window_s = 0.25
+    ebind_min_interval_s = 2.0
+    last_ebind_at = 0.0
 
     # Hold-and-repeat state for volume controls
     vol_hold_active = None        # None, "up", or "down"
@@ -98,6 +101,7 @@ def main():
     # Conditional check
         if pageid == 0:
             nx_set_text(EQ_OBJ_PAGE0, desired_eq)
+            nx_set_text(AUX_OBJ_PAGE0, desired_aux)
     # Conditional check
         elif pageid == 1:
             nx_set_text(EQ_OBJ_PAGE1, desired_eq)
@@ -257,6 +261,7 @@ def main():
                 if pdu == 0x30 and len(avp) >= 9:
                     total_ms = int.from_bytes(avp[0:4], "big")
                     pos_ms = int.from_bytes(avp[4:8], "big")
+                    last_play_status = avp[8]
                     desired_meta["time_cur"] = _fmt_ms(pos_ms)
     # Conditional check
                     if total_ms > 0:
@@ -279,7 +284,11 @@ def main():
     # Conditional check
                     elif event_id == 0x05 and len(avp) >= 5:
                         pos = int.from_bytes(avp[1:5], "big")
-                        desired_meta["time_cur"] = _fmt_ms(pos)
+                        # Playback Position Changed notifications may still be emitted
+                        # around state transitions. Avoid advancing the UI clock while
+                        # paused/stopped to prevent "counting while paused" behavior.
+                        if last_play_status in (0x01, 0x03, 0x04):
+                            desired_meta["time_cur"] = _fmt_ms(pos)
     # Conditional check
                         if nx.current_page == 1 and not aux_mode:
                             flush_page(1)
@@ -328,13 +337,22 @@ def main():
                 bm.pair()
     # Conditional check
             elif tok == b"BT_PLAY":
-                bm.play_pause()
+                if aux_mode:
+                    print("[AUX] Ignoring BT_PLAY while AUX IN is active")
+                else:
+                    bm.play_pause()
     # Conditional check
             elif tok == b"BT_PREV":
-                bm.prev()
+                if aux_mode:
+                    print("[AUX] Ignoring BT_PREV while AUX IN is active")
+                else:
+                    bm.prev()
     # Conditional check
             elif tok == b"BT_NEXT":
-                bm.next()
+                if aux_mode:
+                    print("[AUX] Ignoring BT_NEXT while AUX IN is active")
+                else:
+                    bm.next()
     # Conditional check
             elif tok == b"BT_EQ":
                 mode = bm.next_eq()
@@ -382,7 +400,12 @@ def main():
                     vol_repeat_count = 0
     # Conditional check
             elif tok == b"BT_EBIND":
-                ble_request_erase_bonds()
+                if (now - last_ebind_at) >= ebind_min_interval_s:
+                    if ble_request_erase_bonds():
+                        last_ebind_at = now
+                        print("[BLE] erase-bonds requested")
+                    else:
+                        print("[BLE] erase-bonds request ignored (busy/cooldown)")
 
 # endregion
         # Handle volume hold-and-repeat

--- a/firmware/circuitpython/main.py
+++ b/firmware/circuitpython/main.py
@@ -207,9 +207,8 @@ def main():
             else:
                 print("[AUX] cleared -> enabling AVRCP polling, hiding tAUX1")
                 exit_aux_mode()
-    # Conditional check
-            if nx.current_page == 1:
-                flush_page(1)
+    # Refresh current page to update AUX indicator
+            flush_page(nx.current_page)
 
 # endregion
     # Conditional check

--- a/firmware/circuitpython/main.py
+++ b/firmware/circuitpython/main.py
@@ -406,6 +406,8 @@ def main():
                         print("[BLE] erase-bonds requested")
                     else:
                         print("[BLE] erase-bonds request ignored (busy/cooldown)")
+                else:
+                    print("[BLE] erase-bonds request ignored (ui cooldown)")
 
 # endregion
         # Handle volume hold-and-repeat

--- a/firmware/circuitpython/main.py
+++ b/firmware/circuitpython/main.py
@@ -276,7 +276,13 @@ def main():
                 elif pdu == 0x31 and len(avp) >= 1:
                     event_id = avp[0]
     # Conditional check
-                    if event_id == 0x02:
+                    if event_id == 0x01 and len(avp) >= 2:
+                        # PlaybackStatusChanged: keep local status cache fresh
+                        # between GetPlayStatus polling intervals.
+                        last_play_status = avp[1]
+                        bm.avrcp_register_notification(0x01, interval_s=1)
+    # Conditional check
+                    elif event_id == 0x02:
                         dprint("[AVRCP] TrackChanged -> request metadata")
                         bm.schedule_attrs(0.25)
                         bm.avrcp_reregister_track_changed()

--- a/firmware/circuitpython/nextion/__init__.py
+++ b/firmware/circuitpython/nextion/__init__.py
@@ -1,4 +1,5 @@
 from .display import (
+    AUX_OBJ_PAGE0,
     AUX_OBJ_PAGE1,
     EQ_MAP,
     EQ_OBJ_PAGE0,
@@ -23,5 +24,6 @@ __all__ = (
     "NX_RUNTIME",
     "EQ_OBJ_PAGE0",
     "EQ_OBJ_PAGE1",
+    "AUX_OBJ_PAGE0",
     "AUX_OBJ_PAGE1",
 )

--- a/firmware/circuitpython/nextion/display.py
+++ b/firmware/circuitpython/nextion/display.py
@@ -45,8 +45,9 @@ def ascii_upper_uscore(token):
 
 EQ_OBJ_PAGE0 = "tEQ0"
 EQ_OBJ_PAGE1 = "tEQ1"
-AUX_OBJ_PAGE0 = "tAUX1"
 AUX_OBJ_PAGE1 = "tAUX1"
+# Page 0 intentionally reuses the same Nextion AUX text object name as page 1.
+AUX_OBJ_PAGE0 = AUX_OBJ_PAGE1
 
 # endregion
 NX_RUNTIME = {

--- a/firmware/circuitpython/nextion/display.py
+++ b/firmware/circuitpython/nextion/display.py
@@ -45,6 +45,7 @@ def ascii_upper_uscore(token):
 
 EQ_OBJ_PAGE0 = "tEQ0"
 EQ_OBJ_PAGE1 = "tEQ1"
+AUX_OBJ_PAGE0 = "tAUX1"
 AUX_OBJ_PAGE1 = "tAUX1"
 
 # endregion


### PR DESCRIPTION
Playback position UI gating relied on `last_play_status`, but that cache was only refreshed by periodic `GetPlayStatus` polling. This could leave the UI briefly out of sync around pause/play transitions despite active AVRCP notifications.

- **AVRCP notification handling**
  - Added handling for `REGISTER_NOTIFICATION` event `0x01` (`PlaybackStatusChanged`) in `main.py`.
  - On receipt, update `last_play_status` immediately from the notification payload.

- **Notification lifecycle**
  - Re-register `PlaybackStatusChanged` after handling the event to keep one-shot AVRCP notifications active.

- **Impact**
  - Reduces stale play-state windows between poll intervals.
  - Keeps playback-position update gating aligned with real transport state transitions.

```python
elif pdu == 0x31 and len(avp) >= 1:
    event_id = avp[0]
    if event_id == 0x01 and len(avp) >= 2:
        last_play_status = avp[1]
        bm.avrcp_register_notification(0x01, interval_s=1)
```