### PR TITLE
Harden BLE bond erase flow; add page-aware AUX UI updates and AVRCP state gating

### DIFF
--- a/firmware/circuitpython/blehid/ble.py
+++ b/firmware/circuitpython/blehid/ble.py
@@ -454,19 +454,6 @@ class BleHid:
                     dprint("[BLE] _bleio.adapter.erase_bonding err:", e)
                     ok = False
             else:
-            has_radio_erase = hasattr(self._ble, "erase_bonding")
-            try:
-                if has_radio_erase:
-                    self._ble.erase_bonding()
-                    ok = True
-            except Exception as e:
-                dprint("[BLE] erase_bonding err:", e)
-                ok = False
-
-            # Fallback to _bleio.adapter only when BLERadio does not expose erase_bonding.
-            # If BLERadio.erase_bonding() exists but fails, do not chain another low-level
-            # erase call in the same cycle; this reduces BLE stack stress on ESP32-S3.
-            if not ok and not has_radio_erase:
                 try:
                     if hasattr(self._ble, "erase_bonding"):
                         self._ble.erase_bonding()
@@ -475,13 +462,7 @@ class BleHid:
                     dprint("[BLE] erase_bonding err:", e)
                     ok = False
 
-            if ok:
-                erase_status = "OK"
-            elif has_radio_erase and not ok:
-                erase_status = "FAILED"
-            else:
-                erase_status = "Unavailable on this build"
-            print("[BLE] erase_bonding:", erase_status)
+            print("[BLE] erase_bonding:", "OK" if ok else "Unavailable on this build")
 
             # Brief delay after erase_bonding to allow BLE stack to stabilize
             # before updating name and restarting advertising

--- a/firmware/circuitpython/blehid/ble.py
+++ b/firmware/circuitpython/blehid/ble.py
@@ -436,22 +436,30 @@ class BleHid:
             gc.collect()
 
             ok = False
+            adapter_erase = None
             try:
-                if hasattr(self._ble, "erase_bonding"):
-                    self._ble.erase_bonding()
-                    ok = True
-            except Exception as e:
-                dprint("[BLE] erase_bonding err:", e)
-                ok = False
+                import _bleio
+                adapter_erase = getattr(getattr(_bleio, "adapter", None), "erase_bonding", None)
+            except Exception:
+                adapter_erase = None
 
-            if not ok:
+            # Prefer the adapter erase when available on this build.
+            # Using one erase path per attempt avoids mixed high/low-level
+            # calls in a single cycle, which can destabilize NimBLE.
+            if callable(adapter_erase):
                 try:
-                    import _bleio
-                    if hasattr(_bleio.adapter, "erase_bonding"):
-                        _bleio.adapter.erase_bonding()
-                        ok = True
+                    adapter_erase()
+                    ok = True
                 except Exception as e:
                     dprint("[BLE] _bleio.adapter.erase_bonding err:", e)
+                    ok = False
+            else:
+                try:
+                    if hasattr(self._ble, "erase_bonding"):
+                        self._ble.erase_bonding()
+                        ok = True
+                except Exception as e:
+                    dprint("[BLE] erase_bonding err:", e)
                     ok = False
 
             print("[BLE] erase_bonding:", "OK" if ok else "Unavailable on this build")

--- a/firmware/circuitpython/bm83/bm83.py
+++ b/firmware/circuitpython/bm83/bm83.py
@@ -95,7 +95,7 @@ class Bm83:
         self._last_connected_seen = 0.0
         self._disconnect_hold_s = 2.0
         self._next_playstatus_at = 0.0
-        self._playstatus_period_s = 1.0
+        self._playstatus_period_s = 2.0
         self._next_attrs_at = 0.0
         self._attrs_throttle_s = 1.5
         self._last_attrs_req_at = 0.0

--- a/firmware/circuitpython/main.py
+++ b/firmware/circuitpython/main.py
@@ -5,7 +5,7 @@ import busio
 
 # endregion
 from utils.common import dprint, _fmt_ms, _sanitize_text
-from nextion.display import Nextion, NX_RUNTIME, EQ_OBJ_PAGE0, EQ_OBJ_PAGE1, AUX_OBJ_PAGE1
+from nextion.display import Nextion, NX_RUNTIME, EQ_OBJ_PAGE0, EQ_OBJ_PAGE1, AUX_OBJ_PAGE0, AUX_OBJ_PAGE1
 from blehid.ble import BleHid
 from bm83.bm83 import Bm83
 
@@ -78,8 +78,11 @@ def main():
     last_avrcp_rx_at = 0.0
     last_pos_ms = None
     last_total_ms = None
+    last_play_status = None
     last_voldn_at = 0.0
     mute_window_s = 0.25
+    ebind_min_interval_s = 2.0
+    last_ebind_at = 0.0
 
     # Hold-and-repeat state for volume controls
     vol_hold_active = None        # None, "up", or "down"
@@ -98,6 +101,7 @@ def main():
     # Conditional check
         if pageid == 0:
             nx_set_text(EQ_OBJ_PAGE0, desired_eq)
+            nx_set_text(AUX_OBJ_PAGE0, desired_aux)
     # Conditional check
         elif pageid == 1:
             nx_set_text(EQ_OBJ_PAGE1, desired_eq)
@@ -229,7 +233,7 @@ def main():
     # Conditional check
                 if change == "CONNECTED":
                     print("[BTM] Connected -> register notifications + request metadata")
-                    bm.avrcp_register_notification(0x01, interval_s=1)
+                    bm.avrcp_register_notification(0x01, interval_s=0)
                     bm.avrcp_register_notification(0x02, interval_s=0)
                     bm.avrcp_register_notification(0x05, interval_s=1)
                     bm._next_playstatus_at = now + 0.05
@@ -257,6 +261,7 @@ def main():
                 if pdu == 0x30 and len(avp) >= 9:
                     total_ms = int.from_bytes(avp[0:4], "big")
                     pos_ms = int.from_bytes(avp[4:8], "big")
+                    last_play_status = avp[8]
                     desired_meta["time_cur"] = _fmt_ms(pos_ms)
     # Conditional check
                     if total_ms > 0:
@@ -276,10 +281,16 @@ def main():
                         dprint("[AVRCP] TrackChanged -> request metadata")
                         bm.schedule_attrs(0.25)
                         bm.avrcp_reregister_track_changed()
-    # Conditional check
+                    elif event_id == 0x01 and len(avp) >= 2:
+                        last_play_status = avp[1]
+                    # Conditional check
                     elif event_id == 0x05 and len(avp) >= 5:
                         pos = int.from_bytes(avp[1:5], "big")
-                        desired_meta["time_cur"] = _fmt_ms(pos)
+                        # Playback Position Changed notifications may still be emitted
+                        # around state transitions. Avoid advancing the UI clock while
+                        # paused/stopped to prevent "counting while paused" behavior.
+                        if last_play_status in (0x01, 0x03, 0x04):
+                            desired_meta["time_cur"] = _fmt_ms(pos)
     # Conditional check
                         if nx.current_page == 1 and not aux_mode:
                             flush_page(1)
@@ -328,13 +339,22 @@ def main():
                 bm.pair()
     # Conditional check
             elif tok == b"BT_PLAY":
-                bm.play_pause()
+                if aux_mode:
+                    print("[AUX] Ignoring BT_PLAY while AUX IN is active")
+                else:
+                    bm.play_pause()
     # Conditional check
             elif tok == b"BT_PREV":
-                bm.prev()
+                if aux_mode:
+                    print("[AUX] Ignoring BT_PREV while AUX IN is active")
+                else:
+                    bm.prev()
     # Conditional check
             elif tok == b"BT_NEXT":
-                bm.next()
+                if aux_mode:
+                    print("[AUX] Ignoring BT_NEXT while AUX IN is active")
+                else:
+                    bm.next()
     # Conditional check
             elif tok == b"BT_EQ":
                 mode = bm.next_eq()
@@ -382,7 +402,12 @@ def main():
                     vol_repeat_count = 0
     # Conditional check
             elif tok == b"BT_EBIND":
-                ble_request_erase_bonds()
+                if (now - last_ebind_at) >= ebind_min_interval_s:
+                    if ble_request_erase_bonds():
+                        last_ebind_at = now
+                        print("[BLE] erase-bonds requested")
+                    else:
+                        print("[BLE] erase-bonds request ignored (busy/cooldown)")
 
 # endregion
         # Handle volume hold-and-repeat

--- a/firmware/circuitpython/main.py
+++ b/firmware/circuitpython/main.py
@@ -202,10 +202,10 @@ def main():
             aux_mode_prev = aux_mode
     # Conditional check
             if aux_mode:
-                print("[AUX] inferred -> gating AVRCP polling, showing tAUX1")
+                print("[AUX] inferred -> gating AVRCP polling, showing AUX indicators")
                 enter_aux_mode()
             else:
-                print("[AUX] cleared -> enabling AVRCP polling, hiding tAUX1")
+                print("[AUX] cleared -> enabling AVRCP polling, hiding AUX indicators")
                 exit_aux_mode()
     # Refresh current page to update AUX indicator
             flush_page(nx.current_page)

--- a/firmware/circuitpython/nextion/__init__.py
+++ b/firmware/circuitpython/nextion/__init__.py
@@ -1,4 +1,5 @@
 from .display import (
+    AUX_OBJ_PAGE0,
     AUX_OBJ_PAGE1,
     EQ_MAP,
     EQ_OBJ_PAGE0,
@@ -23,5 +24,6 @@ __all__ = (
     "NX_RUNTIME",
     "EQ_OBJ_PAGE0",
     "EQ_OBJ_PAGE1",
+    "AUX_OBJ_PAGE0",
     "AUX_OBJ_PAGE1",
 )

--- a/firmware/circuitpython/nextion/display.py
+++ b/firmware/circuitpython/nextion/display.py
@@ -45,10 +45,8 @@ def ascii_upper_uscore(token):
 
 EQ_OBJ_PAGE0 = "tEQ0"
 EQ_OBJ_PAGE1 = "tEQ1"
-AUX_OBJ_PAGE0 = "tAUX1"
+AUX_OBJ_PAGE0 = "tAUX0"
 AUX_OBJ_PAGE1 = "tAUX1"
-# Page 0 intentionally reuses the same Nextion AUX text object name as page 1.
-AUX_OBJ_PAGE0 = AUX_OBJ_PAGE1
 
 # endregion
 NX_RUNTIME = {

--- a/firmware/circuitpython/nextion/display.py
+++ b/firmware/circuitpython/nextion/display.py
@@ -45,6 +45,7 @@ def ascii_upper_uscore(token):
 
 EQ_OBJ_PAGE0 = "tEQ0"
 EQ_OBJ_PAGE1 = "tEQ1"
+AUX_OBJ_PAGE0 = "tAUX1"
 AUX_OBJ_PAGE1 = "tAUX1"
 
 # endregion

--- a/tests/test_nextion.py
+++ b/tests/test_nextion.py
@@ -1,4 +1,4 @@
-from nextion.display import Nextion
+from nextion.display import AUX_OBJ_PAGE0, AUX_OBJ_PAGE1, Nextion
 from unittest import mock
 
 
@@ -24,6 +24,11 @@ def test_nextion_enqueue_and_tick():
     nx.enqueue("tEQ0.txt=\"TEST\"")
     nx.tick()
     assert any(b"tEQ0.txt=" in cmd for cmd in uart.written)
+
+
+def test_aux_objects_use_distinct_page_targets():
+    assert AUX_OBJ_PAGE0 == "tAUX0"
+    assert AUX_OBJ_PAGE1 == "tAUX1"
 
 
 def test_nextion_read_token():


### PR DESCRIPTION
This change tightens the BLE bond-erasure path, makes AUX state visible on both Nextion pages, and reduces incorrect AVRCP-driven UI updates while AUX is active or playback is paused/stopped. It also adds a short debounce for repeated E-BIND requests from the UI.

- **BLE bond erasure**
  - Prefer `_bleio.adapter.erase_bonding()` when that low-level API is present
  - Use a single erase path per attempt instead of chaining multiple erase mechanisms in one cycle
  - Keep the BLERadio fallback when the adapter API is unavailable
  - Restore the intended erase block after the merge regression that broke the branch with an indentation error

- **AUX UI synchronization**
  - Add a dedicated page-0 AUX target (`tAUX0`) alongside the page-1 target (`tAUX1`)
  - Update page flushing so AUX state is rendered on whichever page is currently active
  - Keep AUX-mode transitions from depending on unrelated UI refreshes

- **AVRCP/playback state handling**
  - Cache playback status from AVRCP vendor responses
  - Only advance `time_cur` when playback is in a playing-like state
  - Reduce play-status polling frequency to lower UI churn
  - Register playback-status notifications immediately on connect

- **AUX-mode control gating**
  - Ignore `BT_PLAY`, `BT_PREV`, and `BT_NEXT` tokens while AUX mode is inferred
  - Prevent Bluetooth media commands from being sent when the device is effectively in AUX input mode

- **E-BIND cooldown**
  - Add a minimum interval between `BT_EBIND` requests
  - Accept the first request and ignore rapid repeats until the cooldown expires

```python
EQ_OBJ_PAGE0 = "tEQ0"
EQ_OBJ_PAGE1 = "tEQ1"
AUX_OBJ_PAGE0 = "tAUX0"
AUX_OBJ_PAGE1 = "tAUX1"

if aux_mode != aux_mode_prev:
    aux_mode_prev = aux_mode
    if aux_mode:
        enter_aux_mode()
    else:
        exit_aux_mode()
    flush_page(nx.current_page)
```