### PR TITLE
Fix/avrcp register throttle and watchdog

### DIFF
--- a/firmware/circuitpython/lib/bm83/bm83.py
+++ b/firmware/circuitpython/lib/bm83/bm83.py
@@ -45,6 +45,10 @@ class Bm83:
         "_eq_throttle_s",
         "_last_track_changed_reg_at",
         "_track_changed_reg_throttle_s",
+        "_last_status_changed_reg_at",
+        "_status_reg_throttle_s",
+        "_last_pos_changed_reg_at",
+        "_pos_reg_throttle_s",
         "_btm_silence_timeout_s",
         "audio_source",
     )
@@ -133,6 +137,15 @@ class Bm83:
         # TrackChanged re-registration throttle to prevent feedback loops
         self._last_track_changed_reg_at = 0.0
         self._track_changed_reg_throttle_s = 2.0  # Min time between re-registrations
+        # PlaybackStatusChanged / PlaybackPositionChanged re-registration throttles.
+        # Some BM83 firmware revs choke on rapid AVRCP register-notification calls
+        # during CT-side establishment and silently drop the A2DP profile while
+        # leaving the BT link nominally up. Tighter than TrackChanged (2.0 s) since
+        # status/position re-arms fire more frequently in steady state.
+        self._last_status_changed_reg_at = 0.0
+        self._status_reg_throttle_s = 0.5
+        self._last_pos_changed_reg_at = 0.0
+        self._pos_reg_throttle_s = 0.5
         # If no BTM_Status (or other connection-refreshing event) arrives for this
         # many seconds while we think we're connected, assume the radio went silent
         # and flip to disconnected. The AVRCP-silence heuristic in main.py alone
@@ -590,6 +603,31 @@ class Bm83:
         self.avrcp_register_notification(0x02, interval_s=0, db=db)
         return True
 # endregion
+
+# Function: avrcp_reregister_status_changed - Throttled re-register PlaybackStatusChanged
+    def avrcp_reregister_status_changed(self, db=0):
+        """Throttled re-registration for PlaybackStatusChanged.
+
+        Some BM83 firmware revs choke on rapid register-notification calls
+        during AVRCP CT-side establishment, silently dropping the A2DP
+        profile while keeping the link up. Throttle to ~0.5 s.
+        """
+        now = time.monotonic()
+        if (now - self._last_status_changed_reg_at) < self._status_reg_throttle_s:
+            return False
+        self._last_status_changed_reg_at = now
+        self.avrcp_register_notification(0x01, interval_s=0, db=db)
+        return True
+
+# Function: avrcp_reregister_position_changed - Throttled re-register PlaybackPositionChanged
+    def avrcp_reregister_position_changed(self, interval_s=1, db=0):
+        """Throttled re-registration for PlaybackPositionChanged. See above."""
+        now = time.monotonic()
+        if (now - self._last_pos_changed_reg_at) < self._pos_reg_throttle_s:
+            return False
+        self._last_pos_changed_reg_at = now
+        self.avrcp_register_notification(0x05, interval_s=interval_s, db=db)
+        return True
 
 # endregion
     # Loop through items

--- a/firmware/circuitpython/lib/bm83/bm83.py
+++ b/firmware/circuitpython/lib/bm83/bm83.py
@@ -150,7 +150,11 @@ class Bm83:
         # many seconds while we think we're connected, assume the radio went silent
         # and flip to disconnected. The AVRCP-silence heuristic in main.py alone
         # can't clear self.connected, so without this the state sticks forever.
-        self._btm_silence_timeout_s = 30.0
+        # Bumped from 30.0s to 90.0s: paused playback on some BM83 firmwares emits
+        # no BTM_Status / AVRCP traffic for minutes at a time. The new value still
+        # trips on a hung radio (crash, brown-out, UART wedge) but tolerates idle
+        # pauses without falsely demoting self.connected.
+        self._btm_silence_timeout_s = 90.0
 
         # Current audio source reported by BTM_Status (state 0x80/0x81/0x82).
         # None until the first source event arrives. 0x81 means AUX jack is the
@@ -304,9 +308,11 @@ class Bm83:
             out.append((op, params))
             # Any successful inbound frame proves the BM83 is alive. Refresh
             # the connection-watchdog timestamp so the silence watchdog only
-            # trips on an actually-silent radio (not on steady-state BT
-            # playback where BTM_Status doesn't re-emit between transitions).
-            if self.connected:
+            # trips on an actually-silent radio. Exclude BTM_Status itself —
+            # otherwise note_btm_state's _disconnect_hold_s check (2.0 s) is
+            # always-false because we just stamped 'now', and a real
+            # disconnect-state BTM_Status would never demote self.connected.
+            if self.connected and op != self.EVT_BTM_STATUS:
                 self._last_connected_seen = time.monotonic()
             # CircuitPython bytearray doesn't support slice deletion.
             self._rx = self._rx[total:]

--- a/firmware/circuitpython/lib/bm83/bm83.py
+++ b/firmware/circuitpython/lib/bm83/bm83.py
@@ -551,10 +551,11 @@ class Bm83:
     def check_connection_watchdog(self, now=None):
         """Return "DISCONNECTED" if the BM83 has gone completely silent.
 
-        ``_last_connected_seen`` is refreshed on *any* successful inbound frame
-        in ``poll()`` while ``self.connected`` is True — BTM_Status events,
-        AVRCP notifications, metadata responses, play-status replies, etc. —
-        so this watchdog only trips when the radio emits nothing at all for
+        ``_last_connected_seen`` is refreshed on successful inbound non-BTM
+        frames in ``poll()`` while ``self.connected`` is True (for example,
+        AVRCP notifications, metadata responses, and play-status replies).
+        Connected-state BTM_Status events refresh it via ``note_btm_state()``.
+        This watchdog only trips when the radio emits nothing at all for
         ``_btm_silence_timeout_s`` (e.g., crash, brown-out, UART wedged).
         Steady-state playback that triggers only AVRCP traffic (no BTM state
         transitions) must NOT trip this, otherwise the UI will flap into AUX.

--- a/firmware/circuitpython/main.py
+++ b/firmware/circuitpython/main.py
@@ -382,8 +382,8 @@ def main():
                             primary_metadata_missing()
                             or (prev_status != last_play_status and desired_meta.get("time") == TIME_UNKNOWN)
                         ):
-                            dprint("[META] playback start -> request metadata")
-                            bm.schedule_attrs(0.15, force=True)
+                            dprint("[META] playback start -> request metadata (throttled)")
+                            bm.schedule_attrs(0.15)
     # Conditional check
                     elif event_id == 0x02:
                         last_pos_ms = None

--- a/firmware/circuitpython/main.py
+++ b/firmware/circuitpython/main.py
@@ -382,8 +382,8 @@ def main():
                             primary_metadata_missing()
                             or (prev_status != last_play_status and desired_meta.get("time") == TIME_UNKNOWN)
                         ):
-                            dprint("[META] playback start -> request metadata (throttled)")
-                            bm.schedule_attrs(0.15)
+                            dprint("[META] playback start -> request metadata")
+                            bm.schedule_attrs(0.15, force=True)
     # Conditional check
                     elif event_id == 0x02:
                         last_pos_ms = None

--- a/firmware/circuitpython/main.py
+++ b/firmware/circuitpython/main.py
@@ -376,7 +376,7 @@ def main():
                         # between GetPlayStatus polling intervals.
                         prev_status = last_play_status
                         last_play_status = avp[1]
-                        bm.avrcp_register_notification(0x01, interval_s=0)
+                        bm.avrcp_reregister_status_changed()
                         bm.schedule_play_status(0.05)
                         if last_play_status in PLAYING_STATES and (
                             primary_metadata_missing()
@@ -401,7 +401,7 @@ def main():
                             changed = []
                             meta_set("time_cur", _fmt_ms(pos), changed)
                             push_meta_updates(changed)
-                        bm.avrcp_register_notification(0x05, interval_s=1)
+                        bm.avrcp_reregister_position_changed()
     # Conditional check
             elif op == bm.EVT_AVRCP_VENDOR_DEP_RSP:
                 gea = bm.parse_gea_0x5d(params)

--- a/tests/test_bm83.py
+++ b/tests/test_bm83.py
@@ -277,3 +277,38 @@ def test_connection_watchdog_noop_when_disconnected():
     bm = Bm83(None)
     bm.connected = False
     assert bm.check_connection_watchdog() is None
+
+
+def test_status_changed_reregister_throttle():
+    """avrcp_reregister_status_changed is throttled to ~0.5 s."""
+    uart = MockUART()
+    bm = Bm83(uart)
+
+    # First call goes through.
+    assert bm.avrcp_reregister_status_changed() is True
+    assert len(uart.writes) == 1
+
+    # Immediate second call is throttled.
+    assert bm.avrcp_reregister_status_changed() is False
+    assert len(uart.writes) == 1
+
+    # After the throttle window, allowed again.
+    bm._last_status_changed_reg_at = time.monotonic() - (bm._status_reg_throttle_s + 0.1)
+    assert bm.avrcp_reregister_status_changed() is True
+    assert len(uart.writes) == 2
+
+
+def test_position_changed_reregister_throttle():
+    """avrcp_reregister_position_changed is throttled to ~0.5 s."""
+    uart = MockUART()
+    bm = Bm83(uart)
+
+    assert bm.avrcp_reregister_position_changed() is True
+    assert len(uart.writes) == 1
+
+    assert bm.avrcp_reregister_position_changed() is False
+    assert len(uart.writes) == 1
+
+    bm._last_pos_changed_reg_at = time.monotonic() - (bm._pos_reg_throttle_s + 0.1)
+    assert bm.avrcp_reregister_position_changed() is True
+    assert len(uart.writes) == 2

--- a/tests/test_bm83.py
+++ b/tests/test_bm83.py
@@ -312,3 +312,50 @@ def test_position_changed_reregister_throttle():
     bm._last_pos_changed_reg_at = time.monotonic() - (bm._pos_reg_throttle_s + 0.1)
     assert bm.avrcp_reregister_position_changed() is True
     assert len(uart.writes) == 2
+
+
+def test_poll_does_not_refresh_watchdog_on_btm_status():
+    """poll() must NOT stamp _last_connected_seen on BTM_Status frames.
+
+    Otherwise note_btm_state's _disconnect_hold_s check is always-false
+    and a real disconnect-state BTM_Status can never demote self.connected.
+    """
+    uart = MockUART()
+    bm = Bm83(uart)
+    bm.connected = True
+    # Anchor the watchdog timestamp far in the past so we can detect a refresh.
+    stale = time.monotonic() - 100.0
+    bm._last_connected_seen = stale
+
+    # Inject a BTM_Status frame (op=0x01) with a non-connected state byte.
+    btm_frame = bm.frame(Bm83.EVT_BTM_STATUS, bytes([0x00]))
+    uart.to_read = bytearray(btm_frame)
+    uart.in_waiting = len(uart.to_read)
+    events = bm.poll()
+    assert any(op == Bm83.EVT_BTM_STATUS for op, _ in events)
+    # Must remain stale — BTM_Status is excluded from the refresh.
+    assert bm._last_connected_seen == stale
+
+
+def test_poll_refreshes_watchdog_on_non_btm_frame():
+    """poll() refreshes _last_connected_seen on non-BTM inbound frames."""
+    uart = MockUART()
+    bm = Bm83(uart)
+    bm.connected = True
+    stale = time.monotonic() - 100.0
+    bm._last_connected_seen = stale
+
+    # AVRCP vendor response frame — a non-BTM op.
+    avrcp_frame = bm.frame(Bm83.EVT_AVC_VENDOR_RSP, bytes([0x00, 0x00]))
+    uart.to_read = bytearray(avrcp_frame)
+    uart.in_waiting = len(uart.to_read)
+    events = bm.poll()
+    assert any(op == Bm83.EVT_AVC_VENDOR_RSP for op, _ in events)
+    # Must have been refreshed.
+    assert bm._last_connected_seen > stale
+
+
+def test_btm_silence_timeout_default_is_90s():
+    """The watchdog default tolerates idle pauses (>=90s)."""
+    bm = Bm83(None)
+    assert bm._btm_silence_timeout_s >= 90.0


### PR DESCRIPTION
This pull request introduces more robust handling of AVRCP notification re-registration and improves the Bluetooth connection watchdog logic for the BM83 module. It adds throttling to AVRCP PlaybackStatusChanged and PlaybackPositionChanged re-registrations to prevent issues with certain BM83 firmware versions, updates the connection watchdog to avoid false positives during idle playback, and includes comprehensive tests for the new behaviors.

**AVRCP Notification Throttling:**
- Added throttling for `PlaybackStatusChanged` and `PlaybackPositionChanged` AVRCP register-notification calls to prevent rapid re-registrations that can cause some BM83 firmware to drop the A2DP profile. New methods `avrcp_reregister_status_changed` and `avrcp_reregister_position_changed` are introduced in `bm83.py` and used in `main.py` instead of direct calls. [[1]](diffhunk://#diff-c0c068af01e2f04781d9cbbec8be0518d1432216218304112ff235a95a33594dR140-R157) [[2]](diffhunk://#diff-c0c068af01e2f04781d9cbbec8be0518d1432216218304112ff235a95a33594dR613-R637) [[3]](diffhunk://#diff-7d8157d8bcecb5a2d74c91104bc4d8dcc2c5103f269b2823c43d890a12afc312L379-R386) [[4]](diffhunk://#diff-7d8157d8bcecb5a2d74c91104bc4d8dcc2c5103f269b2823c43d890a12afc312L404-R404)
- Internal state variables (`_last_status_changed_reg_at`, `_status_reg_throttle_s`, `_last_pos_changed_reg_at`, `_pos_reg_throttle_s`) are added to support throttling. [[1]](diffhunk://#diff-c0c068af01e2f04781d9cbbec8be0518d1432216218304112ff235a95a33594dR48-R51) [[2]](diffhunk://#diff-c0c068af01e2f04781d9cbbec8be0518d1432216218304112ff235a95a33594dR140-R157)

**Connection Watchdog Improvements:**
- Increased the default silence timeout (`_btm_silence_timeout_s`) from 30s to 90s to tolerate longer idle periods during paused playback, reducing false disconnects.
- Modified the `poll()` method to avoid refreshing the connection watchdog timestamp on `BTM_Status` frames, ensuring that disconnect events are not masked by periodic status reports.

**Testing Enhancements:**
- Added tests to verify throttling behavior for AVRCP notification re-registration and correct watchdog timestamp handling in `test_bm83.py`.